### PR TITLE
Round buffer, create separate WindowSize

### DIFF
--- a/src/audio-init.c
+++ b/src/audio-init.c
@@ -21,6 +21,7 @@
 static void populateSettings(const AudioSettings *, struct sio_par *); 
 static void openOutput(struct sio_hdl **);
 static void suggestSettings(struct sio_hdl *, struct sio_par *);
+static int roundBuffer(AudioSettings *, const struct sio_par *);
 static void setSetting(const unsigned int, const unsigned int,
     unsigned int *, const char *); 
 static void setSettings(AudioSettings *, const struct sio_par *);
@@ -81,16 +82,28 @@ setSetting(const unsigned int expected, const unsigned int reality,
   *field = reality;
 }
 
+static int
+roundBuffer(AudioSettings *aos, const struct sio_par *sp) {
+
+/* Round the buffer size according to hardware suggestions. */
+
+  int frames = aos->Bufsize;
+  frames = frames + sp->round - 1;
+  frames -= frames % sp->round;
+  return frames;
+}
+
 static void
 setSettings(AudioSettings *aos, const struct sio_par *sp) {
 
 /* Runs setSetting() on essential playback parameters. */
 
   setSetting(aos->Bits, sp->bits, &aos->Bits, "bits");
-  setSetting(aos->Bufsize, sp->appbufsz, &aos->Bufsize, "bufsize");
+  setSetting(aos->Bufsize, roundBuffer(aos, sp), &aos->Bufsize, "bufsize");
   setSetting(aos->Chan, sp->pchan, &aos->Chan, "chan");
   setSetting(aos->Rate, sp->rate, &aos->Rate, "rate");
   aos->BufsizeMain = aos->Bufsize * aos->Chan * (aos->Bits / 8);
+  aos->WindowSize = DEFAULT_BUFSIZE * aos->Chan * (aos->Bits / 8);
 }
 
 static void

--- a/src/audio-init.h
+++ b/src/audio-init.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <stdbool.h>
-#include <stdint.h>
 
 #include "audio-settings.h"
 #include "buffers.h"
@@ -16,13 +15,13 @@ typedef struct Audio {
  * written to Audio.MainBuffer, which is finally converted to sound by
  * Audio.Output. */
 
-  bool                  Active;
-  float                 Amplitude;
-  Buffer 	        * MixingBuffer;
-  ByteBuffer          * MainBuffer;
-  struct sio_hdl      * Output;
-  AudioSettings         Settings;
-  Voices                Voices;
+  bool                    Active;
+  float                   Amplitude;
+  Buffer                * MixingBuffer;
+  ByteBuffer            * MainBuffer;
+  struct sio_hdl        * Output;
+  AudioSettings           Settings;
+  Voices                  Voices;
 } Audio;
 
 void makeAudio(Audio *, const int, char **);

--- a/src/audio-settings.h
+++ b/src/audio-settings.h
@@ -12,13 +12,14 @@ typedef struct AudioSettings {
  * of this code need to make use of any of them. Other structs might contain
  * pointers to or local copies of these read-only values. */
 
-  bool         EchoNotes;
-  unsigned int Bits;
-  unsigned int Bufsize;
-  unsigned int BufsizeMain;
-  unsigned int Chan;
-  unsigned int Rate;
-  unsigned int Polyphony;
+  bool          EchoNotes;
+  unsigned int  Bits;
+  unsigned int  Bufsize;     /* TODO - bytes or frames? */
+  unsigned int  BufsizeMain; /* Output bufsize, in bytes */
+  unsigned int  Chan;
+  unsigned int  Rate;
+  unsigned int  Polyphony;
+  unsigned int  WindowSize;  /* Size of user input sampling window, in bytes */
 } AudioSettings;
 
 void makeAudioSettings(AudioSettings *, const int, char **);

--- a/src/constants/defaults.h
+++ b/src/constants/defaults.h
@@ -10,14 +10,19 @@
 /* Bit depth of an individual sample */
 #define DEFAULT_BITS 16
 
-/* Audio output buffer size (in frames) */
-#define DEFAULT_BUFSIZE 960
+/* Sample rate */
+#define DEFAULT_RATE 48000
+
+/* Number of times to poll for user input per second */
+#define DEFAULT_RESOLUTION 375
+
+/* Ideal audio output buffer size (in frames, not bytes). Even if audio output
+ * does not respect this size, it will be used for the timing of user input,
+ * ensuring a resolution of DEFAULT_RESOLUTION  */
+#define DEFAULT_BUFSIZE (DEFAULT_RATE / DEFAULT_RESOLUTION)
 
 /* Number of channels */
 #define DEFAULT_CHAN 1
-
-/* Sample rate */
-#define DEFAULT_RATE 48000
 
 /* Number of simultaneous voices */
 #define DEFAULT_POLYPHONY 8


### PR DESCRIPTION
Next steps:

- Remove threading and write based on `WindowSize`.
- Simplify output buffers.
- Make output rolling to handle mismatch with `WindowSize`.