### PR TITLE
Band adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ set the ADSR of the carrier, and:
     S
     R
 
-sets the ADSR of the modulator. All commands accept values between 0.0 and 1.0, where 0 indicates an instantaneous effect, and 1 is a 10 second long envelope stage.
+sets the ADSR of the modulator. All commands are in seconds.
 
 Listen to how the following settings affect boar:
 

--- a/TODO
+++ b/TODO
@@ -10,12 +10,15 @@ succession.
 [YES] Env time in seconds:
 Rather than having an arbitrary limit, express envelope time in seconds. May
 complicate external MIDI control if such a thing ever moves beyond note on/off,
-but this is not a priority.
+but this is not a priority. This is currently implemented, but is buggy with
+long envelopes due to floating point resolution of phase. Unsure if it's worth
+converting to double for extra long envelopes.
 
 [YES] Band limiting adjustment:
 All complex wave forms are band limited just below the aliasing limit, which
 still might be too harmonically complex to actually sound good. Should have
-a command that tells boar to read +/- wavetables from the default. 
+a command that tells boar to read +/- wavetables from the default. This is
+currently implemented, but only to mute harmonics, not augment them.
 
 [YES] New parser:
 Parser can be better. Maybe take ideas from boar-parser experiment repo.

--- a/boar.1
+++ b/boar.1
@@ -53,6 +53,10 @@ Sets the envelope attack wave shape for the carrier (a.) or modulator (A.).
 Sets the left/right audio output channel balance. 0.5 represents full volume in both left/right channels. 0.0 represents full volume in the left channel with the right one muted. 1.0 represents full volume in the right channel with the left one muted.
 .El
 .Bl -tag -width Ds
+.It c/C [uint]
+Adjust the harmonic complexity muting on carrier (c) or modulator (C). At the default value of zero, the full harmonics of a wave are audible, but higher values will produce a more mellow signal. This has no effect on sines or noise.
+.El
+.Bl -tag -width Ds
 .It d/D [ufloat]
 Sets the envelope decay for the carrier (d) or modulator (D). This is the amount of time the parameter being enveloped takes to reach its sustain level after the attack has taken place. Values between 0.0 and 1.0 are honored.
 .El

--- a/boar.1
+++ b/boar.1
@@ -42,7 +42,7 @@ A comment. Any text behind this is ignored. Useful in annotating files full of b
 .El
 .Bl -tag -width Ds
 .It a/A [ufloat]
-Sets the envelope attack for the carrier (a) or modulator (A). This is the amount of time the parameter being enveloped takes to reach its full effect. Values between 0.0 and 1.0 are honored.
+Sets the envelope attack for the carrier (a) or modulator (A). This is the amount of seconds the parameter being enveloped takes to reach its full effect.
 .El
 .Bl -tag -width Ds
 .It a./A. [int]
@@ -58,7 +58,7 @@ Adjust the harmonic complexity muting on carrier (c) or modulator (C). At the de
 .El
 .Bl -tag -width Ds
 .It d/D [ufloat]
-Sets the envelope decay for the carrier (d) or modulator (D). This is the amount of time the parameter being enveloped takes to reach its sustain level after the attack has taken place. Values between 0.0 and 1.0 are honored.
+Sets the envelope decay for the carrier (d) or modulator (D). This is the amount of seconds the parameter being enveloped takes to reach its sustain level after the attack has taken place.
 .El
 .Bl -tag -width Ds
 .It d./D. [int]
@@ -94,7 +94,7 @@ Quits the program.
 .El
 .Bl -tag -width Ds
 .It r/R [ufloat]
-Sets the envelope release for the carrier (r) or modulator (R). This is the amount of time the parameter being enveloped takes to reach zero after its corresponding note has been turned off. Values between 0.0 and 1.0 are honored.
+Sets the envelope release for the carrier (r) or modulator (R). This is the amount of seconds the parameter being enveloped takes to reach zero after its corresponding note has been turned off.
 .El
 .Bl -tag -width Ds
 .It r./R. [int]

--- a/src/constants/funcs.h
+++ b/src/constants/funcs.h
@@ -20,8 +20,14 @@
 /* (A.) sets modulator attack waveform */
 #define FUNC_MOD_ATTACK_WAVE FUNC_DEF('A', TYPE_PERIOD)
 
-/* (b) sets left/right channel balance*/
+/* (b) sets left/right channel balance */
 #define FUNC_CHAN_BALANCE FUNC_DEF('b', TYPE_NORMAL)
+
+/* (c) sets wave complexity */
+#define FUNC_WAVE_COMPLEXITY FUNC_DEF('c', TYPE_NORMAL)
+
+/* (C) sets modulator wave complexity */
+#define FUNC_MOD_WAVE_COMPLEXITY FUNC_DEF('C', TYPE_NORMAL)
 
 /* (d) sets decay */
 #define FUNC_DECAY FUNC_DEF('d', TYPE_NORMAL)

--- a/src/constants/types.h
+++ b/src/constants/types.h
@@ -65,7 +65,7 @@
 static const unsigned int TYPE_SIGNATURES_PURE[58] = {
   TYPE_UFLOAT,    /* A */
   TYPE_UNDEFINED, /* B */
-  TYPE_UNDEFINED, /* C */
+  TYPE_UINT,      /* C */
   TYPE_UFLOAT,    /* D */
   TYPE_UNDEFINED, /* E */
   TYPE_UNDEFINED, /* F */
@@ -97,7 +97,7 @@ static const unsigned int TYPE_SIGNATURES_PURE[58] = {
   TYPE_UNDEFINED, /* ignored */
   TYPE_UFLOAT,    /* a */
   TYPE_UFLOAT,    /* b */
-  TYPE_UNDEFINED, /* c */
+  TYPE_UINT,      /* c */
   TYPE_UFLOAT,    /* d */
   TYPE_UNDEFINED, /* e */
   TYPE_UNDEFINED, /* f */

--- a/src/envelope.c
+++ b/src/envelope.c
@@ -18,15 +18,19 @@ static void incrementDecay(Env *);
 static void incrementRelease(Env *);
 
 static float
-envSpeed(const unsigned int rate, const float f) {
+envSpeed(const unsigned int rate, float f) {
 
 /* Derives the increment value of an envelope stage, and hence its speed, from
  * the overall sample rate of the program "rate", and a user-specified float
- * value between 0.0 and 1.0 "f". */
+ * value between 0.0 and 1.0 "f", where "f" is the number of seconds the
+ * envelope stage should last. Due to float (not double) resolution, the
+ * timing becomes inaccurate above 30 seconds. Unsure if longer envelopes are
+ * worth converting all phase to a higher resolution. */
 
-  float curve = unipolar(expCurve(f));
-
-  return 1.0f / ((float)rate * curve * MAX_ENV_TIME);
+  if (!f) {
+    f = 0.000001f;
+  }
+  return 1.0f / ((float)rate * f);
 }
 
 static void
@@ -163,7 +167,7 @@ setAttackLevel(Envs *es, const float f) {
 
 /* Sets the attack speed for an envelope. */
 
-  setEnvLevel(es->Rate, &es->Attack, truncateFloat(f, 1.0f));
+  setEnvLevel(es->Rate, &es->Attack, liftFloat(f, 0.0f));
 }
 
 void
@@ -171,7 +175,7 @@ setDecayLevel(Envs *es, const float f) {
 
 /* Sets the decay speed for an envelope. */
 
-  setEnvLevel(es->Rate, &es->Decay, truncateFloat(f, 1.0f));
+  setEnvLevel(es->Rate, &es->Decay, liftFloat(f, 0.0f));
 }
 
 void
@@ -187,7 +191,7 @@ setReleaseLevel(Envs *es, const float f) {
 
 /* Sets the release speed for an envelope. */
 
-  setEnvLevel(es->Rate, &es->Release, truncateFloat(f, 1.0f));
+  setEnvLevel(es->Rate, &es->Release, liftFloat(f, 0.0f));
 }
 
 void

--- a/src/repl.c
+++ b/src/repl.c
@@ -142,6 +142,12 @@ dispatchCmd(Repl *r) {
     case FUNC_WAVE:
       selectWave(&carrier->Wave, arg->I);
       break;
+    case FUNC_MOD_WAVE_COMPLEXITY:
+      setWaveComplexity(voices, false, arg->I);
+      break;
+    case FUNC_WAVE_COMPLEXITY:
+      setWaveComplexity(voices, true, arg->I);
+      break;
     case FUNC_MOD_FIXED:
       setFixedRate(voices, false, arg->F);
       break;

--- a/src/synthesis.h
+++ b/src/synthesis.h
@@ -1,23 +1,27 @@
 #pragma once
 
+#include <stdbool.h>
+
 #include "envelope.h"
 #include "wave.h"
 
 typedef struct Osc {
 
 /* The primitive sound generating type. For every sound sample value generated,
- * Osc.Phase is incremented by Osc.Pitch, which serves as the index of
- * WAVE_SINE where the sample resides. Osc.Amplitude governs the depth of
- * modulation or the volume of the note, depending upon whether Osc is a
- * modulator or carrier. Osc.KeyMod is the aggregate values of the velocity
- * and key follow settings of the struck key that engaged the Osc. At step i of
- * every buffer-filling cycle, Osc.Phase * Osc.Amplitude * Osc.KeyMod is
- * written to Osc.Buffer[i]. */
+ * Osc.Phase is incremented by Osc.Pitch, which serves as the index of Osc.Wave,
+ * where the sample resides. Osc.Amplitude governs the modulation depth or 
+ * volume of the note, depending upon whether Osc is a modulator or carrier. 
+ * Osc.KeyMod is the aggregate values of the velocity and key follow settings of 
+ * the struck key that engaged the Osc. Osc.Complexity adjusts the harmonic
+ * richness of the signal offsetting +/- which band-limited wavetable to read.
+ * At step i of every buffer-filling cycle, 
+ * Osc.Phase * Osc.Amplitude * Osc.KeyMod is written to Osc.Buffer[i]. */
 
   float   KeyMod;
   float   Amplitude;
   float   Phase;
   float   Pitch;
+  int   * Complexity;
   float * Buffer;
   Wave  * Wave;
 } Osc;
@@ -40,10 +44,11 @@ typedef struct Operators {
  * individual child Operators point to. No oscillator information is contained
  * here, as that is decided on a Voice by Voice basis. */
 
-  float       FixedRate;    
-  float       Ratio;
-  Wave        Wave;
-  Envs        Env;
+  int   Complexity;
+  float FixedRate;    
+  float Ratio;
+  Wave  Wave;
+  Envs  Env;
 
 } Operators;
 

--- a/src/voice.c
+++ b/src/voice.c
@@ -173,6 +173,18 @@ setFixedRate(Voices *vs, const bool isCarrier, const float r) {
 }
 
 void
+setWaveComplexity(Voices *vs, const bool isCarrier, const int n) {
+
+/* Set the harmonic complexity offset of the carrier or modulator signal. */  
+
+  if (isCarrier) {
+    vs->Carrier.Complexity = n;
+  } else {
+    vs->Modulator.Complexity = n;
+  }
+}
+
+void
 setModulation(Voices *vs, const float m) {
 
 /* Sets modulation index on all voices. Since this variable makes use of
@@ -219,6 +231,7 @@ makeOperator(Operators *os, Operator *op, float *b) {
   op->FixedRate = &os->FixedRate;
   op->Ratio = &os->Ratio;
   op->Osc.Buffer = b;
+  op->Osc.Complexity = &os->Complexity;
   op->Osc.Wave = &os->Wave;
   makeNoise(&op->Osc.Wave->Noise);
   makeEnv(&os->Env, &op->Env);
@@ -240,6 +253,7 @@ makeOperators(Operators *os, const unsigned int rate) {
 
 /* Initializes a Voices.Operators type. */    
 
+  os->Complexity = 0;
   makeEnvs(&os->Env, rate);
   selectWave(&os->Wave, WAVE_TYPE_SINE);
 }

--- a/src/voice.h
+++ b/src/voice.h
@@ -53,6 +53,7 @@ void voiceOff(Voices *, const uint16_t);
 void pollVoice(Voice *);
 void setPitchRatio(Voices *, const bool, const float);
 void setFixedRate(Voices *, const bool, const float);
+void setWaveComplexity(Voices *, const bool, const int);
 void setModulation(Voices *, const float);
 void makeVoices(Voices *, float *, const AudioSettings *);
 void killVoices(Voices *);

--- a/src/wave.h
+++ b/src/wave.h
@@ -21,10 +21,10 @@ typedef struct Wave {
 /* A wrapper around the actual wavetable with type information. Wave. Polarity
  * marks the direction a wavetable should be read in. */
 
-  float          Polarity;
-  WaveType       Type;
-  const float ** Table;
-  Noise          Noise;
+  float            Polarity;
+  WaveType         Type;
+  const float   ** Table;
+  Noise            Noise;
 } Wave;
 
 void selectWave(Wave *, const int);


### PR DESCRIPTION
- Attenuate wavetable harmonics with `c/C` command.
- Envelope times are now specified in seconds, but unstable beyond 30 seconds due to limited phase resolution.